### PR TITLE
edit API:connection

### DIFF
--- a/map_project/map_app/models.py
+++ b/map_project/map_app/models.py
@@ -6,8 +6,10 @@ class Connections(models.Model):
     user_id2 = models.ForeignKey('Users', models.DO_NOTHING, db_column='user_id2', related_name = 'user_id2')
     status = models.CharField(max_length=48)
     point = models.IntegerField(blank=True, null=True)
+    times = models.IntegerField(default=1)
     created_by = models.DateTimeField(blank=True, null=True)
     updated_by = models.DateTimeField(blank=True, null=True)
+
 
     class Meta:
         managed = False

--- a/map_project/map_app/views.py
+++ b/map_project/map_app/views.py
@@ -104,17 +104,17 @@ def connection(request):
 	result = {
 		"hash1":hs1,
 		"hash2":hs2,
-		"userId1": UserId1,
-		"userId2": UserId2,
+		"userId1":UserId1,
+		"userId2":UserId2,
 		"status":status,
 		"distance":distance,
 		"point":point,
-		"pt":Users.objects.get(pk=UserId1).point + point,
 		"freq":frequency,
 	}
 	try:
 		# frequency != 0: # if exist connection_id
 		Connections.objects.get(connection_id=hs1)
+		point = Connections.objects.get(connection_id=hs1).point + point
 		createDay = Connections.objects.get(connection_id=hs1).created_by
 		saveConnection(hs1,hs2,UserId1,UserId2,status,createDay,today,point,frequency)
 		savepoint(UserId1,UserId2,point)


### PR DESCRIPTION
## API:connectionの修正
- connectiionの回数を保存
    - models.pyにtimesを宣言
- statusがonlineとofflineでconnecion_idを分けて保存
    - ハッシュ生成を`UserId1 + UserId2 + status` , `UserId2 + UserId1 + status`で行うことでstatusによってconnection_id(ハッシュ値)が変化する
- DBへ保存する操作を関数としてまとめる
    - 2回目以降の登録では`created_by`を更新しない
    - frequencyをインクリメントしてく
- デバック用に戻り値を余分に表示